### PR TITLE
fix newline for securetty

### DIFF
--- a/manifests/securetty.pp
+++ b/manifests/securetty.pp
@@ -12,7 +12,7 @@
 class os_hardening::securetty (
   $root_ttys = ['console','tty1','tty2','tty3','tty4','tty5','tty6']
 ){
-  $ttys = join( $root_ttys, '\n')
+  $ttys = join( $root_ttys, "\n")
   file { '/etc/securetty':
     ensure  => present,
     content => template( 'os_hardening/securetty.erb' ),


### PR DESCRIPTION
the existing code results in this because '\n' is not a newline for puppet, we need to use "\n" instead

```
+# A list of TTYs, from which root can log in
+# see `man securetty` for reference
+console\ntty1\ntty2\ntty3\ntty4\ntty5\ntty6
```