### PR TITLE
bugfix: replace non-ascii char in login.defs

### DIFF
--- a/templates/login.defs.erb
+++ b/templates/login.defs.erb
@@ -87,7 +87,7 @@ KILLCHAR  025
 UMASK   <%= @umask %>
 
 # Enable setting of the umask group bits to be the same as owner bits (examples: `022` -> `002`, `077` -> `007`) for non-root users, if the uid is the same as gid, and username is the same as the primary group name.
-# If set to yes, userdel will remove the user´s group if it contains no more members, and useradd will create by default a group with the name of the user.
+# If set to yes, userdel will remove the user's group if it contains no more members, and useradd will create by default a group with the name of the user.
 USERGROUPS_ENAB yes
 
 


### PR DESCRIPTION
Thanks to @spielkind for bringing this up!

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>