### PR TITLE
Fixed minimize_access on RHEL7

### DIFF
--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -25,6 +25,7 @@ class os_hardening::minimize_access (
   # remove write permissions from path folders ($PATH) for all regular users
   # this prevents changing any system-wide command from normal users
   file { $folders:
+    links   => 'follow',
     ensure  => 'directory',
     mode    => 'go-w',
     recurse => true,

--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -25,8 +25,8 @@ class os_hardening::minimize_access (
   # remove write permissions from path folders ($PATH) for all regular users
   # this prevents changing any system-wide command from normal users
   file { $folders:
-    links   => 'follow',
     ensure  => 'directory',
+    links   => 'follow',
     mode    => 'go-w',
     recurse => true,
   }


### PR DESCRIPTION
Hi,

I'm new to github, so please excuse me if I missed some established procedure for a pull request.

On RHEL7, /bin an /sbin are links to /usr/bin, /usr/sbin. Without the below change, the module will break the /bin, /sbin links and the system won't work anymore.

Cheers,
Thomas