### PR TITLE
Stack protection via randomize_va_space

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This module provides secure configuration of your base OS with hardening.
   load this modules via initramfs if enable_module_loading is false
 * `enable_sysrq = false`
 * `enable_core_dump = false`
+* `enable_stack_protection = true`
+  for Address Space Layout Randomization. ASLR can help defeat certain types of buffer overflow attacks. ASLR can locate the base, libraries, heap, and stack at random positions in a process's address space, which makes it difficult for an attacking program to predict the memory address of the next instruction.
 * `cpu_vendor = 'intel'`
   only required if `enable_module_loading = false`: set the CPU vendor for modules to load
 * `root_ttys = ["console","tty1","tty2","tty3","tty4","tty5","tty6"]`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,17 +101,17 @@ class os_hardening(
 
   if $configure_sysctl {
     class {'os_hardening::sysctl':
-    enable_module_loading   => $enable_module_loading,
-    load_modules            => $load_modules,
-    cpu_vendor              => $cpu_vendor,
-    desktop_enabled         => $desktop_enabled,
-    enable_ipv4_forwarding  => $enable_ipv4_forwarding,
-    enable_ipv6             => $enable_ipv6,
-    enable_ipv6_forwarding  => $enable_ipv6_forwarding,
-    arp_restricted          => $arp_restricted,
-    enable_sysrq            => $enable_sysrq,
-    enable_core_dump        => $enable_core_dump,
-    enable_stack_protection => $enable_stack_protection,
+      enable_module_loading   => $enable_module_loading,
+      load_modules            => $load_modules,
+      cpu_vendor              => $cpu_vendor,
+      desktop_enabled         => $desktop_enabled,
+      enable_ipv4_forwarding  => $enable_ipv4_forwarding,
+      enable_ipv6             => $enable_ipv6,
+      enable_ipv6_forwarding  => $enable_ipv6_forwarding,
+      arp_restricted          => $arp_restricted,
+      enable_sysrq            => $enable_sysrq,
+      enable_core_dump        => $enable_core_dump,
+      enable_stack_protection => $enable_stack_protection,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class os_hardening(
   $arp_restricted           = true,
   $enable_sysrq             = false,
   $enable_core_dump         = false,
+  $enable_stack_protection  = true,
 ) {
   # Prepare
   # -------
@@ -100,16 +101,17 @@ class os_hardening(
 
   if $configure_sysctl {
     class {'os_hardening::sysctl':
-    enable_module_loading  => $enable_module_loading,
-    load_modules           => $load_modules,
-    cpu_vendor             => $cpu_vendor,
-    desktop_enabled        => $desktop_enabled,
-    enable_ipv4_forwarding => $enable_ipv4_forwarding,
-    enable_ipv6            => $enable_ipv6,
-    enable_ipv6_forwarding => $enable_ipv6_forwarding,
-    arp_restricted         => $arp_restricted,
-    enable_sysrq           => $enable_sysrq,
-    enable_core_dump       => $enable_core_dump,
+    enable_module_loading   => $enable_module_loading,
+    load_modules            => $load_modules,
+    cpu_vendor              => $cpu_vendor,
+    desktop_enabled         => $desktop_enabled,
+    enable_ipv4_forwarding  => $enable_ipv4_forwarding,
+    enable_ipv6             => $enable_ipv6,
+    enable_ipv6_forwarding  => $enable_ipv6_forwarding,
+    arp_restricted          => $arp_restricted,
+    enable_sysrq            => $enable_sysrq,
+    enable_core_dump        => $enable_core_dump,
+    enable_stack_protection => $enable_stack_protection,
     }
   }
 }

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -20,6 +20,7 @@ class os_hardening::sysctl (
   $arp_restricted         = true,
   $enable_sysrq           = false,
   $enable_core_dump       = false,
+  $enable_stack_protection = true,
 ){
 
   # set variables
@@ -172,6 +173,13 @@ class os_hardening::sysctl (
     sysctl { 'kernel.sysrq': value => '0' }
   }
 
+  # Enable stack protection by randomizing kernel va space
+  if $enable_stack_protection {
+    sysctl { 'kernel.randomize_va_space': value => '2' }
+  } else {
+    sysctl { 'kernel.randomize_va_space': value => '0' }
+  }
+  
   # Prevent core dumps with SUID. These are usually only needed by developers and may contain sensitive information.
   if $enable_core_dump {
     sysctl { 'fs.suid_dumpable': value => '1' }

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -10,16 +10,16 @@
 # Configures PAM
 #
 class os_hardening::sysctl (
-  $enable_module_loading  = true,
-  $load_modules           = [],
-  $cpu_vendor             = 'intel',
-  $desktop_enabled        = false,
-  $enable_ipv4_forwarding = false,
-  $enable_ipv6            = false,
-  $enable_ipv6_forwarding = false,
-  $arp_restricted         = true,
-  $enable_sysrq           = false,
-  $enable_core_dump       = false,
+  $enable_module_loading   = true,
+  $load_modules            = [],
+  $cpu_vendor              = 'intel',
+  $desktop_enabled         = false,
+  $enable_ipv4_forwarding  = false,
+  $enable_ipv6             = false,
+  $enable_ipv6_forwarding  = false,
+  $arp_restricted          = true,
+  $enable_sysrq            = false,
+  $enable_core_dump        = false,
   $enable_stack_protection = true,
 ){
 

--- a/spec/classes/sysctl_spec.rb
+++ b/spec/classes/sysctl_spec.rb
@@ -115,6 +115,20 @@ describe 'os_hardening::sysctl' do
     end
   end
 
+  context 'with enable_stack_protection => true' do
+    let(:params) { { :enable_stack_protection => true } }
+    it do
+      should contain_sysctl('kernel.randomize_va_space').with_value('2')
+    end
+  end
+
+  context 'with enable_stack_protection => false' do
+    let(:params) { { :enable_stack_protection => false } }
+    it do
+      should contain_sysctl('kernel.randomize_va_space').with_value('0')
+    end
+  end
+
   context 'with enable_core_dump => true' do
     let(:params) { { :enable_core_dump => true } }
     it do


### PR DESCRIPTION
I added the randomize_va_space sysctl key for stack protection. It is active by default, but I figured it wouldn't hurt to monitor it via puppet.
I had to change some indentation along the way, so the diff looks bigger then it actually is.